### PR TITLE
Build allowAccessControlOrigin and httpsRedirect middleware

### DIFF
--- a/server.js
+++ b/server.js
@@ -7,9 +7,32 @@ const configuration = require('./knexfile')[environment];
 const database = require('knex')(configuration);
 const port = process.env.PORT || 3000;
 
+const accessControlAllowOrigin = (request, response, next) => { // Middleware used to set Access-Control-Allow-Origin header in response to avoid CORS errors
+  response.header('Access-Control-Allow-Origin', '*');
+  response.header(
+    'Access-Control-Allow-Headers',
+    'Origin, X-Requested-With, Content-Type, Accept'
+  );
+  next();
+};
+
+const httpsRedirect = (request, response, next) => {
+  if( request.headers['x-forwarded-proto'] !== 'https') {
+    return response.redirect('https://' + request.get('host') + request.url);
+  }
+
+  next();
+}
+
 app.locals.title = 'Garage Bin';
 
 app.set('port', port);
+
+if (environment !== 'development' && environment !== 'test') {
+  app.use(httpsRedirect)
+} else if (environment !== 'test') {
+  app.use(accessControlAllowOrigin)
+}
 
 app
   .use(bodyParser.json())

--- a/server.js
+++ b/server.js
@@ -7,11 +7,12 @@ const configuration = require('./knexfile')[environment];
 const database = require('knex')(configuration);
 const port = process.env.PORT || 3000;
 
-const accessControlAllowOrigin = (request, response, next) => { // Middleware used to set Access-Control-Allow-Origin header in response to avoid CORS errors
+const accessControlAllowOrigin = (request, response, next) => {
   response.header('Access-Control-Allow-Origin', '*');
+  response.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE,OPTIONS');
   response.header(
     'Access-Control-Allow-Headers',
-    'Origin, X-Requested-With, Content-Type, Accept'
+    'Content-Type, Authorization, Content-Length, X-Requested-With, x-token'
   );
   next();
 };


### PR DESCRIPTION
- Builds `accessControlALlowOrigin` and `httpsRedirect` middleware
- Builds conditional check for above mentioned middleware to screen for development and testing environments